### PR TITLE
added support for the velodyne VLP-16

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,18 @@
 rock_library(velodyne_lidar
-    SOURCES velodyneDataDriver.cpp velodynePositioningDriver.cpp pointcloudConvertHelper.cpp
-    HEADERS velodyneDataDriver.hpp velodynePositioningDriver.hpp pointcloudConvertHelper.hpp velodyneConstants.hpp velodyneProtocolTypes.hpp MultilevelLaserScan.h gps_rmc_type.h
+    SOURCES velodyneDataDriver.cpp
+            VelodyneHDL32EDriver.cpp
+            VelodyneVLP16Driver.cpp
+            velodynePositioningDriver.cpp
+            pointcloudConvertHelper.cpp
+    HEADERS velodyneDataDriver.hpp
+            VelodyneHDL32EDriver.hpp
+            VelodyneVLP16Driver.hpp
+            velodynePositioningDriver.hpp
+            pointcloudConvertHelper.hpp
+            velodyneConstants.hpp
+            velodyneProtocolTypes.hpp
+            MultilevelLaserScan.h
+            gps_rmc_type.h
     DEPS_PKGCONFIG base-lib iodrivers_base aggregator)
 
 rock_executable(velodyne_lidar_bin test_velodyneDriver.cpp

--- a/src/VelodyneHDL32EDriver.cpp
+++ b/src/VelodyneHDL32EDriver.cpp
@@ -1,0 +1,84 @@
+#include "VelodyneHDL32EDriver.hpp"
+
+using namespace velodyne_lidar;
+
+static const uint16_t UPPER_HEADER_BYTES = 0xEEFF; //The byte indicating a upper shot
+static const uint16_t LOWER_HEADER_BYTES = 0xDDFF; //The byte indicating a lower shot
+static const unsigned int NUM_LASERS = 32;
+static const unsigned int FIRING_ORDER[] = {31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1,
+                                            30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0};
+static const double DRIVER_BROADCAST_FREQ_HZ = 1808.0;
+static const double VERTICAL_RESOLUTION = 1.0 + 1.0/3.0; // vertical resolution in degree
+static const double VERTICAL_START_ANGLE = -VERTICAL_RESOLUTION * 8.0; // vertical start angle in degree
+static const double VERTICAL_END_ANGLE = VERTICAL_RESOLUTION * 23.0; // vertical end angle in degree
+
+VelodyneHDL32EDriver::VelodyneHDL32EDriver() : VelodyneDataDriver(velodyne_lidar::VELODYNE_HDL32E, DRIVER_BROADCAST_FREQ_HZ)
+{
+
+}
+
+VelodyneHDL32EDriver::~VelodyneHDL32EDriver()
+{
+
+}
+
+double VelodyneHDL32EDriver::getBroadcastFrequency()
+{
+    return DRIVER_BROADCAST_FREQ_HZ;
+}
+
+bool VelodyneHDL32EDriver::convertScanToSample(base::samples::DepthMap& sample, bool copy_remission)
+{
+    if(packets.empty())
+        return false;
+
+    if(packets[0].packet.return_mode == DualReturn)
+        throw std::runtime_error("Return mode dual return is not supported!");
+
+    // prepare sample
+    sample.reset();
+    unsigned horizontal_steps = packets.size() * VELODYNE_NUM_SHOTS;
+    unsigned measurement_count = horizontal_steps * NUM_LASERS;
+    sample.distances.resize(measurement_count);
+    if(copy_remission)
+        sample.remissions.resize(measurement_count);
+    sample.timestamps.resize(horizontal_steps);
+    sample.time = packets.back().time[VELODYNE_NUM_SHOTS-1];
+    sample.horizontal_size = horizontal_steps;
+    sample.vertical_size = NUM_LASERS;
+    sample.horizontal_interval.resize(horizontal_steps);
+    sample.vertical_interval.push_back(base::Angle::deg2Rad(VERTICAL_START_ANGLE));
+    sample.vertical_interval.push_back(base::Angle::deg2Rad(VERTICAL_END_ANGLE));
+    sample.horizontal_projection = base::samples::DepthMap::POLAR;
+    sample.vertical_projection = base::samples::DepthMap::POLAR;
+    base::samples::DepthMap::DepthMatrixMap distances = sample.getDistanceMatrixMap();
+    base::samples::DepthMap::DepthMatrixMap remissions = base::samples::DepthMap::DepthMatrixMap(sample.remissions.data(), sample.vertical_size, sample.horizontal_size);
+
+    for(unsigned i = 0; i < packets.size(); i++)
+    {
+        for(unsigned j = 0; j < VELODYNE_NUM_SHOTS; j++)
+        {
+            unsigned column = (i * VELODYNE_NUM_SHOTS) + j;
+            sample.timestamps[column] = packets[i].time[j];
+            const velodyne_fire& shot = packets[i].packet.shots[j];
+            sample.horizontal_interval[column] = base::Angle::fromDeg(360.0 - (double)shot.rotational_pos * 0.01).getRad();
+            for(unsigned k = 0; k < NUM_LASERS; k++)
+            {
+                const vel_laser_t &laser = shot.lasers[FIRING_ORDER[k]];
+                if(laser.distance == 0) // zero means no return within max range
+                    distances(k, column) = base::infinity<base::samples::DepthMap::scalar>();
+                else if(laser.distance <= MIN_SENSING_DISTANCE) // dismiss all values under 1m
+                    distances(k, column) = 0.f;
+                else
+                    distances(k, column) = (float)laser.distance * 0.002f; // velodyne acquires in 2mm-units
+
+                if(copy_remission)
+                    remissions(k, column) = (float)laser.intensity / 255.0f;
+            }
+        }
+    }
+
+    packets.clear();
+    current_batch_size = 0;
+    return true;
+}

--- a/src/VelodyneHDL32EDriver.hpp
+++ b/src/VelodyneHDL32EDriver.hpp
@@ -1,0 +1,30 @@
+#ifndef _VELODYNE_HDL32E_DRIVER_HPP_
+#define _VELODYNE_HDL32E_DRIVER_HPP_
+
+#include "velodyneDataDriver.hpp"
+
+namespace velodyne_lidar
+{
+
+class VelodyneHDL32EDriver : public VelodyneDataDriver
+{
+public:
+    VelodyneHDL32EDriver();
+    virtual ~VelodyneHDL32EDriver();
+
+   /**
+    * Converts a full scan to a DepthMap sample.
+    * Also clears all collected packets of the corresponding laser head.
+    * @returns true on success, false if nothing to convert.
+    */
+    virtual bool convertScanToSample(base::samples::DepthMap& sample, bool copy_remission = true);
+
+   /**
+    * Return frequency of the arriving data samples
+    */
+    virtual double getBroadcastFrequency();
+};
+
+}
+
+#endif

--- a/src/VelodyneVLP16Driver.cpp
+++ b/src/VelodyneVLP16Driver.cpp
@@ -1,0 +1,116 @@
+#include "VelodyneVLP16Driver.hpp"
+#include <base/Time.hpp>
+
+using namespace velodyne_lidar;
+
+static const uint16_t VLP16_HEADER_BYTES = 0xFFEE; //VLP-16 identification bytes
+static const unsigned int NUM_LASERS = 16; // The number of lasers per shot
+static const unsigned int FIRING_ORDER[] = {15, 13, 11, 9, 7, 5, 3, 1,
+                                            14, 12, 10, 8, 6, 4, 2, 0};
+static const double DRIVER_BROADCAST_FREQ_HZ = 754.0; //The rate of broadcast packets.
+static const double VERTICAL_RESOLUTION = 2.0; // vertical resolution in degree
+static const double VERTICAL_START_ANGLE = -VERTICAL_RESOLUTION * 7.5;
+static const double VERTICAL_END_ANGLE = VERTICAL_RESOLUTION * 7.5; // vertical end angle in degree
+static const uint64_t CYCLE_TIME = 55.296; // cycle time of one firing in micro seconds
+
+VelodyneVLP16Driver::VelodyneVLP16Driver() : VelodyneDataDriver(velodyne_lidar::VELODYNE_VLP16, DRIVER_BROADCAST_FREQ_HZ)
+{
+
+}
+
+VelodyneVLP16Driver::~VelodyneVLP16Driver()
+{
+
+}
+
+double VelodyneVLP16Driver::getBroadcastFrequency()
+{
+    return DRIVER_BROADCAST_FREQ_HZ;
+}
+
+bool VelodyneVLP16Driver::convertScanToSample(base::samples::DepthMap& sample, bool copy_remission)
+{
+    if(packets.empty())
+        return false;
+
+    if(packets[0].packet.return_mode == DualReturn)
+        throw std::runtime_error("Return mode dual return is not supported!");
+
+    // prepare sample
+    sample.reset();
+    unsigned horizontal_steps = 2 * packets.size() * VELODYNE_NUM_SHOTS;
+    unsigned measurement_count = horizontal_steps * NUM_LASERS;
+    sample.distances.resize(measurement_count);
+    if(copy_remission)
+        sample.remissions.resize(measurement_count);
+    sample.timestamps.resize(horizontal_steps);
+    sample.time = packets.back().time[VELODYNE_NUM_SHOTS-1] + base::Time::fromMicroseconds(CYCLE_TIME);
+    sample.horizontal_size = horizontal_steps;
+    sample.vertical_size = NUM_LASERS;
+    sample.horizontal_interval.resize(horizontal_steps);
+    sample.vertical_interval.push_back(base::Angle::deg2Rad(VERTICAL_START_ANGLE));
+    sample.vertical_interval.push_back(base::Angle::deg2Rad(VERTICAL_END_ANGLE));
+    sample.horizontal_projection = base::samples::DepthMap::POLAR;
+    sample.vertical_projection = base::samples::DepthMap::POLAR;
+    base::samples::DepthMap::DepthMatrixMap distances = sample.getDistanceMatrixMap();
+    base::samples::DepthMap::DepthMatrixMap remissions = base::samples::DepthMap::DepthMatrixMap(sample.remissions.data(), sample.vertical_size, sample.horizontal_size);
+
+    for(unsigned i = 0; i < packets.size(); i++)
+    {
+        for(unsigned j = 0; j < VELODYNE_NUM_SHOTS; j++)
+        {
+            const velodyne_fire& shot = packets[i].packet.shots[j];
+            // handle first firing
+            unsigned column = (i * VELODYNE_NUM_SHOTS + j) * 2;
+            sample.timestamps[column] = packets[i].time[j];
+            sample.horizontal_interval[column] = base::Angle::fromDeg(360.0 - (double)shot.rotational_pos * 0.01).getRad();
+
+            for(unsigned k = 0; k < NUM_LASERS; k++)
+            {
+                const vel_laser_t &laser = shot.lasers[FIRING_ORDER[k]];
+                if(laser.distance == 0) // zero means no return within max range
+                    distances(k, column) = base::infinity<base::samples::DepthMap::scalar>();
+                else if(laser.distance <= MIN_SENSING_DISTANCE) // dismiss all values under 1m
+                    distances(k, column) = 0.f;
+                else
+                    distances(k, column) = (float)laser.distance * 0.002f; // velodyne acquires in 2mm-units
+
+                if(copy_remission)
+                    remissions(k, column) = (float)laser.intensity / 255.0f;
+            }
+            // handle second firing
+            column++;
+            sample.horizontal_interval[column] = base::NaN<double>();
+            for(unsigned k = 0; k < NUM_LASERS; k++)
+            {
+                const vel_laser_t &laser = shot.lasers[NUM_LASERS + FIRING_ORDER[k]];
+                if(laser.distance == 0) // zero means no return within max range
+                    distances(k, column) = base::infinity<base::samples::DepthMap::scalar>();
+                else if(laser.distance <= MIN_SENSING_DISTANCE) // dismiss all values under 1m
+                    distances(k, column) = 0.f;
+                else
+                    distances(k, column) = (float)laser.distance * 0.002f; // velodyne acquires in 2mm-units
+
+                if(copy_remission)
+                    remissions(k, column) = (float)laser.intensity / 255.0f;
+            }
+        }
+    }
+
+    // interpolate angles and timestamps for all odd entries
+    base::Angle angle_step;
+    for(unsigned column = 1; column < sample.horizontal_size - 1; column += 2)
+    {
+        base::Angle angle_before = base::Angle::fromRad(sample.horizontal_interval[column - 1]);
+        base::Angle angle_after = base::Angle::fromRad(sample.horizontal_interval[column + 1]);
+        angle_step = (angle_after - angle_before) * 0.5;
+        sample.horizontal_interval[column] = (angle_before + angle_step).getRad();
+        sample.timestamps[column] = sample.timestamps[column - 1] + (sample.timestamps[column + 1] - sample.timestamps[column - 1]) * 0.5;
+    }
+    sample.timestamps[sample.horizontal_size - 1] = sample.time;
+    sample.horizontal_interval[sample.horizontal_size - 1] = (base::Angle::fromRad(sample.horizontal_interval[sample.horizontal_size - 2]) + angle_step).getRad();
+
+    packets.clear();
+    current_batch_size = 0;
+    return true;
+}

--- a/src/VelodyneVLP16Driver.hpp
+++ b/src/VelodyneVLP16Driver.hpp
@@ -1,0 +1,30 @@
+#ifndef _VELODYNE_VLP16_DRIVER_HPP_
+#define _VELODYNE_VLP16_DRIVER_HPP_
+
+#include "velodyneDataDriver.hpp"
+
+namespace velodyne_lidar
+{
+
+class VelodyneVLP16Driver : public VelodyneDataDriver
+{
+public:
+    VelodyneVLP16Driver();
+    virtual ~VelodyneVLP16Driver();
+
+    /**
+     * Converts a full scan to a DepthMap sample.
+     * Also clears all collected packets of the corresponding laser head.
+     * @returns true on success, false if nothing to convert.
+     */
+    virtual bool convertScanToSample(base::samples::DepthMap& sample, bool copy_remission = true);
+
+    /**
+     * Return frequency of the arriving data samples
+     */
+    virtual double getBroadcastFrequency();
+};
+
+}
+
+#endif

--- a/src/test_velodyneDriver.cpp
+++ b/src/test_velodyneDriver.cpp
@@ -48,7 +48,7 @@
 #include <stdio.h>
 #include <string>
 
-#include "velodyneDataDriver.hpp"
+#include "VelodyneHDL32EDriver.hpp"
 
 using namespace std;
 
@@ -113,7 +113,7 @@ int main(int argc, char **argv) // need these args for getopt(-long)
   }
   
 
-  velodyne_lidar::VelodyneDataDriver m_velodyneDriver;
+  velodyne_lidar::VelodyneHDL32EDriver m_velodyneDriver;
   
   m_velodyneDriver.openUDP("", velodyne_lidar::VELODYNE_DATA_UDP_PORT);
   

--- a/src/velodyneConstants.hpp
+++ b/src/velodyneConstants.hpp
@@ -1,29 +1,42 @@
 #ifndef _VELODYNE_CONSTANTS_HPP_
 #define _VELODYNE_CONSTANTS_HPP_
 
+#include <vector>
+
+
 namespace velodyne_lidar
 {
-    static const unsigned int VELODYNE_NUM_LASERS = 32; // The number of lasers per shot
+
     static const unsigned int VELODYNE_NUM_SHOTS = 12; // The number of shots per packet
+    static const unsigned int VELODYNE_NUM_LASER_CHANNELS = 32; // The number of lasers per shot
     static const unsigned int VELODYNE_ORIENTATION_READINGS = 3; // The number of orientation readings
     static const unsigned int MIN_SENSING_DISTANCE = 500; //1m in 2mm units
     static const unsigned int MAX_SENSING_DISTANCE = 35000; //70m in 2mm units
     static const unsigned int VELODYNE_DATA_MSG_BUFFER_SIZE = 1206; //The size of a data packet
     static const unsigned int VELODYNE_POSITIONING_MSG_BUFFER_SIZE = 512; //The size of a positioning packet
 
-    static const double VELODYNE_DRIVER_BROADCAST_FREQ_HZ = 1808.0; //The rate of broadcast packets. See Velodyne hdl-32e manual page 11.
     static const unsigned int VELODYNE_DATA_UDP_PORT = 2368; //The port the Velodyne sends laser data to
     static const unsigned int VELODYNE_POSITIONING_UDP_PORT = 8308; //The port the Velodyne sends positioning data to
 
-    static const uint16_t VELODYNE_UPPER_HEADER_BYTES = 0xEEFF; //The byte indicating a upper shot
-    static const uint16_t VELODYNE_LOWER_HEADER_BYTES = 0xDDFF; //The byte indicating a lower shot
-    
-    static const unsigned int VELODYNE_FIRING_ORDER[] = {31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1,
-                                                         30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0};
-                                
-    static const double VELODYNE_VERTICAL_RESOLUTION = 1.0 + 1.0/3.0; // vertical resolution in degree
-    static const double VELODYNE_VERTICAL_START_ANGLE = -VELODYNE_VERTICAL_RESOLUTION * 8.0; // vertical start angle in degree
-    static const double VELODYNE_VERTICAL_END_ANGLE = VELODYNE_VERTICAL_RESOLUTION * 23.0; // vertical end angle in degree
+    /**
+     * Return mode of the light signal
+     */
+    enum ReturnMode
+    {
+        StrongestReturn = 0x37,
+        LastReturn = 0x38,
+        DualReturn = 0x39
+    };
+
+    /**
+     * Sensor type
+     */
+    enum SensorType
+    {
+        VELODYNE_HDL64E = 0x20,
+        VELODYNE_HDL32E = 0x21,
+        VELODYNE_VLP16 = 0x22
+    };
 };
 
 #endif

--- a/src/velodyneDataDriver.hpp
+++ b/src/velodyneDataDriver.hpp
@@ -14,12 +14,6 @@ namespace aggregator
 namespace velodyne_lidar
 {
 
-enum LaserHead
-{
-    LowerHead,
-    UpperHead
-};
-
 class VelodyneDataDriver : public iodrivers_base::Driver 
 {
     struct StampedDataPacket
@@ -29,7 +23,7 @@ class VelodyneDataDriver : public iodrivers_base::Driver
     };
 
 public:
-    VelodyneDataDriver();
+    VelodyneDataDriver(SensorType sensor_type, double broadcast_frequency);
     virtual ~VelodyneDataDriver();
 
     /**
@@ -49,7 +43,7 @@ public:
      * Also clears all collected packets of the corresponding laser head.
      * @returns true on success, false if nothing to convert.
      */
-    bool convertScanToSample(base::samples::DepthMap& sample, LaserHead head = UpperHead, bool copy_remission = true);
+    virtual bool convertScanToSample(base::samples::DepthMap& sample, bool copy_remission = true) = 0;
 
     /**
      * Clears all collected packets.
@@ -77,6 +71,11 @@ public:
     int64_t getPacketReceivedCount();
 
     /**
+     * Return frequency of the arriving data samples
+     */
+    virtual double getBroadcastFrequency() = 0;
+
+    /**
      * Prints the packet
      */
     void print_packet(velodyne_data_packet_t &);
@@ -93,6 +92,7 @@ protected:
      */
     void addNewPacket(const StampedDataPacket& packet);
 
+    SensorType sensor_type;
     uint64_t target_batch_size;
     uint64_t current_batch_size;
     uint16_t last_rotational_pos;
@@ -101,8 +101,7 @@ protected:
     int64_t packets_lost;
     int64_t expected_packet_period;
     aggregator::TimestampEstimator* timestamp_estimator;
-    std::vector<StampedDataPacket> upper_head;
-    std::vector<StampedDataPacket> lower_head;
+    std::vector<StampedDataPacket> packets;
 };
 
 };

--- a/src/velodyneProtocolTypes.hpp
+++ b/src/velodyneProtocolTypes.hpp
@@ -14,16 +14,16 @@ namespace velodyne_lidar
     } __attribute__((packed)) vel_laser_t;
 
     typedef struct velodyne_fire {
-        uint16_t lower_upper;
+        uint16_t laser_header;
         uint16_t rotational_pos; // 0-35999  divide by 100 for degrees
-        vel_laser_t lasers[VELODYNE_NUM_LASERS]; 
+        vel_laser_t lasers[VELODYNE_NUM_LASER_CHANNELS]; 
     } __attribute__((packed)) velodyne_fire_t ;
 
     typedef struct velodyne_data_packet {
         velodyne_fire_t shots[VELODYNE_NUM_SHOTS];  
         uint32_t gps_timestamp; // in microseconds from the top of the hour
-        uint8_t status_type;
-        uint8_t status_value;
+        uint8_t return_mode;
+        uint8_t sensor_type;
         
         velodyne_data_packet()
         {


### PR DESCRIPTION
The driver implementation was split up into a class handling the VLP-16 and one handling the HDL32.
Also some changes due to the velodyne firmware > 3.0. regarding the return mode and sensor type have been done.
The untested support of the HDL-64E was removed for now, but could be implemented in the future.