### PR TITLE
Add include of linux/sockios.h

### DIFF
--- a/src/velodyneDataDriver.cpp
+++ b/src/velodyneDataDriver.cpp
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <assert.h>
+#include <linux/sockios.h>
 #include <sys/ioctl.h>
 #include <sys/errno.h>
 #include <sys/socket.h>


### PR DESCRIPTION
Definition of SIOCGSTAMP was moved in Kernel 5.2 headers:
https://github.com/torvalds/linux/commit/0768e17073dc527ccd18ed5f96ce85f9985e9115